### PR TITLE
Streamline implementation details for performance and readability

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -98,13 +98,13 @@ class Component {
 	 * @throws Exception
 	 */
 	private function getRootNode( DOMDocument $document ) {
-		$rootNodes = iterator_to_array( $document->documentElement->childNodes->item( 0 )->childNodes );
+		$rootNodes = $document->documentElement->childNodes->item( 0 )->childNodes;
 
-		if ( count( $rootNodes ) > 1 ) {
+		if ( $rootNodes->length > 1 ) {
 			throw new Exception( 'Template should have only one root node' );
 		}
 
-		return $rootNodes[0];
+		return $rootNodes->item( 0 );
 	}
 
 	/**
@@ -171,7 +171,7 @@ class Component {
 	private function handleAttributeBinding( DOMElement $node, array $data ) {
 		/** @var DOMAttr $attribute */
 		foreach ( iterator_to_array( $node->attributes ) as $attribute ) {
-			if ( !preg_match( '/^:[\-\_\w]+$/', $attribute->name ) ) {
+			if ( !preg_match( '/^:[\w-]+$/', $attribute->name ) ) {
 				continue;
 			}
 

--- a/src/FilterExpressionParsing/ParseResult.php
+++ b/src/FilterExpressionParsing/ParseResult.php
@@ -50,7 +50,7 @@ class ParseResult {
 	 * @return ParsedExpression
 	 */
 	public function toExpression( JsExpressionParser $expressionParser, array $filters ) {
-		if ( count( $this->filterCalls ) === 0 ) {
+		if ( $this->filterCalls === [] ) {
 			return $expressionParser->parse( $this->expressions[0] );
 		}
 

--- a/src/JsParsing/BasicJsExpressionParser.php
+++ b/src/JsParsing/BasicJsExpressionParser.php
@@ -11,10 +11,10 @@ class BasicJsExpressionParser implements JsExpressionParser {
 	 */
 	public function parse( $expression ) {
 		$expression = $this->normalizeExpression( $expression );
-		if ( strpos( $expression, '!' ) === 0 ) { // ! operator application
+		if ( strncmp( $expression, '!', 1 ) === 0 ) {
 			return new NegationOperator( $this->parse( substr( $expression, 1 ) ) );
-		} elseif ( strpos( $expression, "'" ) === 0 ) {
-			return new StringLiteral( substr( $expression, 1, strlen( $expression ) - 2 ) );
+		} elseif ( strncmp( $expression, "'", 1 ) === 0 ) {
+			return new StringLiteral( substr( $expression, 1, -1 ) );
 		} else {
 			$parts = explode( '.', $expression );
 			return new VariableAccess( $parts );


### PR DESCRIPTION
I did not actually benchmarked these. The actual performance gain might be negligible. However, I still believe it is worth applying these optimizations. The motivation is not only to make this code (potentially) faster, but also simpler and more easy to read. For example, the goal of the comparison `count() === 0` is **not** to actually count the number of elements, but to check if it's empty. This becomes much more obvious with `empty()` or `=== []`.