### PR TITLE
Run PHPCS on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ sudo: false
 
 install: travis_retry composer install --prefer-source
 
-script: composer phpunit
+script: composer test


### PR DESCRIPTION
The config is there, so use it.
Otherwise it could be as well removed.