### PR TITLE
Update PHP code sniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^4.8.35",
-		"wikibase/wikibase-codesniffer": "^0.4.1",
+		"wikibase/wikibase-codesniffer": "^1.1.0",
 		"wmde/hamcrest-html-matchers": "^0.1.0"
 	},
 	"autoload-dev": {

--- a/src/FilterExpressionParsing/FilterParser.php
+++ b/src/FilterExpressionParsing/FilterParser.php
@@ -4,7 +4,7 @@ namespace WMDE\VueJsTemplating\FilterExpressionParsing;
 
 class FilterParser {
 
-	const VALID_DIVISION_CHAR_REGEX = '/[\w).+\-_$\]]/';
+	private const VALID_DIVISION_CHAR_REGEX = '/[\w).+\-_$\]]/';
 
 	private $filters = [];
 

--- a/tests/integration/FixtureTest.php
+++ b/tests/integration/FixtureTest.php
@@ -9,13 +9,15 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use WMDE\VueJsTemplating\Templating;
 
+/**
+ * @coversNothing
+ */
 class FixtureTest extends TestCase {
 
 	/**
-	 * @test
 	 * @dataProvider provideFixtures
 	 */
-	public function phpRenderingEqualsVueJsRendering( $template, array $data, $expectedResult ) {
+	public function testPhpRenderingEqualsVueJsRendering( $template, array $data, $expectedResult ) {
 		$templating = new Templating();
 		$filters = [
 			'message' => 'strval',

--- a/tests/php/FilterExpressionParsing/FilterParserTest.php
+++ b/tests/php/FilterExpressionParsing/FilterParserTest.php
@@ -7,13 +7,15 @@ use WMDE\VueJsTemplating\FilterExpressionParsing\FilterCall;
 use WMDE\VueJsTemplating\FilterExpressionParsing\FilterParser;
 use WMDE\VueJsTemplating\FilterExpressionParsing\ParseResult;
 
+/**
+ * @covers \WMDE\VueJsTemplating\FilterExpressionParsing\FilterParser
+ */
 class FilterParserTest extends TestCase {
 
 	/**
-	 * @test
 	 * @dataProvider provideParseCases
 	 */
-	public function parseTest( $expression, $expectedResult ) {
+	public function testParse( $expression, $expectedResult ) {
 		$filterParser = new FilterParser();
 
 		$result = $filterParser->parse( $expression );

--- a/tests/php/FilterExpressionParsing/ParseResultTest.php
+++ b/tests/php/FilterExpressionParsing/ParseResultTest.php
@@ -7,11 +7,14 @@ use WMDE\VueJsTemplating\FilterExpressionParsing\FilterCall;
 use WMDE\VueJsTemplating\FilterExpressionParsing\ParseResult;
 use WMDE\VueJsTemplating\JsParsing\BasicJsExpressionParser;
 
+/**
+ * @covers \WMDE\VueJsTemplating\FilterExpressionParsing\ParseResult
+ */
 class ParseResultTest extends TestCase {
 
 	private $defaultFilters;
 
-	protected function setUp() {
+	protected function setUp(): void {
 		$this->defaultFilters = [
 			'duplicate' => function ( $str ) {
 				return $str . $str;
@@ -28,10 +31,7 @@ class ParseResultTest extends TestCase {
 		parent::setUp();
 	}
 
-	/**
-	 * @test
-	 */
-	public function toExpression_SingleExpressionWithoutFilters_CreatesThisExpression() {
+	public function testToExpression_SingleExpressionWithoutFilters_CreatesThisExpression() {
 		$expressionParser = new BasicJsExpressionParser();
 		$parseResult = new ParseResult( [ "'a'" ], [] );
 
@@ -40,10 +40,7 @@ class ParseResultTest extends TestCase {
 		$this->assertEquals( 'a', $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function toExpression_SingleExpressionWithFilter_CreatesThisExpression() {
+	public function testToExpression_SingleExpressionWithFilter_CreatesThisExpression() {
 		$expressionParser = new BasicJsExpressionParser();
 		$parseResult = new ParseResult( [ "'a'" ], [ new FilterCall( 'duplicate', [] ) ] );
 
@@ -52,10 +49,7 @@ class ParseResultTest extends TestCase {
 		$this->assertEquals( 'aa', $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function toExpression_SingleExpressionWithTwoFilters_CreatesThisExpression() {
+	public function testToExpression_SingleExpressionWithTwoFilters_CreatesThisExpression() {
 		$expressionParser = new BasicJsExpressionParser();
 		$parseResult = new ParseResult(
 			[ "'a'" ],
@@ -70,10 +64,7 @@ class ParseResultTest extends TestCase {
 		$this->assertEquals( 'aaaa', $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function toExpression_SingleExpressionWithFiltersHavingArguments_CreatesThisExpression() {
+	public function testToExpression_SingleExpressionWithFiltersHavingArgs_CreatesThisExpression() {
 		$expressionParser = new BasicJsExpressionParser();
 		$parseResult = new ParseResult(
 			[ "'a'" ],
@@ -88,10 +79,7 @@ class ParseResultTest extends TestCase {
 		$this->assertEquals( 'abc', $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function toExpression_TwoExpressionWithFilter_CreatesThisExpression() {
+	public function testToExpression_TwoExpressionWithFilter_CreatesThisExpression() {
 		$expressionParser = new BasicJsExpressionParser();
 		$parseResult = new ParseResult(
 			[ "'a'", "'b'" ],

--- a/tests/php/JsParsing/BasicJsExpressionParserTest.php
+++ b/tests/php/JsParsing/BasicJsExpressionParserTest.php
@@ -5,12 +5,12 @@ namespace WMDE\VueJsTemplating\Test\JsParsing;
 use PHPUnit\Framework\TestCase;
 use WMDE\VueJsTemplating\JsParsing\BasicJsExpressionParser;
 
+/**
+ * @covers \WMDE\VueJsTemplating\JsParsing\BasicJsExpressionParser
+ */
 class BasicJsExpressionParserTest extends TestCase {
 
-	/**
-	 * @test
-	 */
-	public function canParseString() {
+	public function testCanParseString() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser();
 
 		$parsedExpression = $jsExpressionEvaluator->parse( "'some string'" );
@@ -19,10 +19,7 @@ class BasicJsExpressionParserTest extends TestCase {
 		$this->assertEquals( 'some string', $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function canParsePropertyAccess() {
+	public function testCanParsePropertyAccess() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser();
 
 		$parsedExpression = $jsExpressionEvaluator->parse( "variable.property" );
@@ -31,22 +28,16 @@ class BasicJsExpressionParserTest extends TestCase {
 		$this->assertEquals( 'some value', $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function canParseNegationOperator() {
+	public function testCanParseNegationOperator() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser();
 
 		$negation = $jsExpressionEvaluator->parse( "!variable" );
 
-		$this->assertEquals( true, $negation->evaluate( [ 'variable' => false ] ) );
-		$this->assertEquals( false, $negation->evaluate( [ 'variable' => true ] ) );
+		$this->assertTrue( $negation->evaluate( [ 'variable' => false ] ) );
+		$this->assertFalse( $negation->evaluate( [ 'variable' => true ] ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function ignoresTrailingAndLeadingSpaces() {
+	public function testIgnoresTrailingAndLeadingSpaces() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser();
 
 		$parsedExpression = $jsExpressionEvaluator->parse( " 'some string' " );

--- a/tests/php/JsParsing/CachingExpressionParserTest.php
+++ b/tests/php/JsParsing/CachingExpressionParserTest.php
@@ -8,12 +8,12 @@ use WMDE\VueJsTemplating\JsParsing\CachingExpressionParser;
 use WMDE\VueJsTemplating\JsParsing\JsExpressionParser;
 use WMDE\VueJsTemplating\JsParsing\StringLiteral;
 
+/**
+ * @covers \WMDE\VueJsTemplating\JsParsing\CachingExpressionParser
+ */
 class CachingExpressionParserTest extends TestCase {
 
-	/**
-	 * @test
-	 */
-	public function parse_CallsInternalParserAndReturnsItsResult() {
+	public function testParse_CallsInternalParserAndReturnsItsResult() {
 		$expectedExpression = new StringLiteral( 'some string' );
 
 		$internalParser = $this->prophesize( JsExpressionParser::class );
@@ -26,10 +26,7 @@ class CachingExpressionParserTest extends TestCase {
 		$this->assertSame( $expectedExpression, $result );
 	}
 
-	/**
-	 * @test
-	 */
-	public function parse_SameExpression_GetExactlySameObject() {
+	public function testParse_SameExpression_GetExactlySameObject() {
 		$cachingExpressionParser = new CachingExpressionParser( new BasicJsExpressionParser() );
 
 		$expression1 = $cachingExpressionParser->parse( "'some string'" );
@@ -38,10 +35,7 @@ class CachingExpressionParserTest extends TestCase {
 		$this->assertSame( $expression1, $expression2 );
 	}
 
-	/**
-	 * @test
-	 */
-	public function parse_IgnoresSurroundingSpaces_GetExactlySameObject() {
+	public function testParse_IgnoresSurroundingSpaces_GetExactlySameObject() {
 		$cachingExpressionParser = new CachingExpressionParser( new BasicJsExpressionParser() );
 
 		$expression1 = $cachingExpressionParser->parse( "'some string'" );

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -6,92 +6,65 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use WMDE\VueJsTemplating\Templating;
 
+/**
+ * @covers \WMDE\VueJsTemplating\Templating
+ */
 class TemplatingTest extends TestCase {
 
-	/**
-	 * @test
-	 */
-	public function justASingleEmptyHtmlElement() {
+	public function testJustASingleEmptyHtmlElement() {
 		$result = $this->createAndRender( '<div></div>', [] );
 
 		assertThat( $result, is( equalTo( '<div></div>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateHasTwoRootNodes_ThrowsAnException() {
+	public function testTemplateHasTwoRootNodes_ThrowsAnException() {
 		$this->setExpectedException( Exception::class );
 		$this->createAndRender( '<p></p><p></p>', [] );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateHasOnClickHandler_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandler_RemoveHandlerFormOutput() {
 		$result = $this->createAndRender( '<div v-on:click="doStuff"></div>', [] );
 
 		assertThat( $result, is( equalTo( '<div></div>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateHasOnClickHandlerAndPreventDefault_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandlerAndPreventDefault_RemoveHandlerFormOutput() {
 		$result = $this->createAndRender( '<div v-on:click.prevent="doStuff"></div>', [] );
 
 		assertThat( $result, is( equalTo( '<div></div>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateHasOnClickHandlerInSomeChildNode_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandlerInSomeChildNode_RemoveHandlerFormOutput() {
 		$result = $this->createAndRender( '<p><a v-on:click="doStuff"></a></p>', [] );
 
 		assertThat( $result, is( equalTo( '<p><a></a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateHasOnClickHandlerInGrandChildNode_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandlerInGrandChildNode_RemoveHandlerFormOutput() {
 		$result = $this->createAndRender( '<p><b><a v-on:click="doStuff"></a></b></p>', [] );
 
 		assertThat( $result, is( equalTo( '<p><b><a></a></b></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithSingleMustacheVariable_ReplacesVariableWithGivenValue() {
+	public function testTemplateWithSingleMustacheVariable_ReplacesVariableWithGivenValue() {
 		$result = $this->createAndRender( '<p>{{value}}</p>', [ 'value' => 'some value' ] );
 
 		assertThat( $result, is( equalTo( '<p>some value</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithVariableAndDiacritcsInValue_ReplacesVariableWithEncodedValue() {
+	public function testTemplateWithVariableAndDiacritcsInValue_ReplacesVariableWithEncodedValue() {
 		$result = $this->createAndRender( '<p>{{value}}</p>', [ 'value' => 'inglés' ] );
 
 		assertThat( $result, is( equalTo( '<p>inglés</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithVariableAndValueInKorean_ReplacesVariableWithEncodedValue() {
+	public function testTemplateWithVariableAndValueInKorean_ReplacesVariableWithEncodedValue() {
 		$result = $this->createAndRender( '<p>{{value}}</p>', [ 'value' => '한국어' ] );
 
 		assertThat( $result, is( equalTo( '<p>한국어</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithVhtmlVariable_ReplacesVariableWithGivenValue() {
+	public function testTemplateWithVhtmlVariable_ReplacesVariableWithGivenValue() {
 		$result = $this->createAndRender(
 			'<div><div v-html="value"></div></div>',
 			[ 'value' => '<p>some value</p>' ]
@@ -100,10 +73,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<div><div><p>some value</p></div></div>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithVhtmlAndDiacritcsInValue_ReplacesVariableWithEncodedValue() {
+	public function testTemplateWithVhtmlAndDiacritcsInValue_ReplacesVariableWithEncodedValue() {
 		$result = $this->createAndRender(
 			'<div><div v-html="value"></div></div>',
 			[ 'value' => '<p>inglés</p>' ]
@@ -112,10 +82,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<div><div><p>inglés</p></div></div>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithVhtmlAndValueInKorean_ReplacesVariableWithEncodedValue() {
+	public function testTemplateWithVhtmlAndValueInKorean_ReplacesVariableWithEncodedValue() {
 		$result = $this->createAndRender(
 			'<div><div v-html="value"></div></div>',
 			[ 'value' => '<p>한국어</p>' ]
@@ -124,44 +91,29 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<div><div><p>한국어</p></div></div>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithMustacheVariable_VariableIsUndefined_ThrowsException() {
+	public function testTemplateWithMustacheVariable_VariableIsUndefined_ThrowsException() {
 		$this->setExpectedException( Exception::class );
 		$this->createAndRender( '<p>{{value}}</p>', [] );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithFilter_FilterIsUndefined_ThrowsException() {
+	public function testTemplateWithFilter_FilterIsUndefined_ThrowsException() {
 		$this->setExpectedException( Exception::class );
 		$this->createAndRender( '<p>{{value|nonexistentFilter}}</p>', [ 'value' => 'some value' ] );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithMustacheVariableSurroundedByText_ReplacesVariableWithGivenValue() {
+	public function testTemplateWithMustacheVariableSurroundedByText_ReplacesVariableWithGivenValue() {
 		$result = $this->createAndRender( '<p>before {{value}} after</p>', [ 'value' => 'some value' ] );
 
 		assertThat( $result, is( equalTo( '<p>before some value after</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithMustacheHavingStringLiteral_JustPrintString() {
+	public function testTemplateWithMustacheHavingStringLiteral_JustPrintString() {
 		$result = $this->createAndRender( "<p>before {{'string'}} after</p>", [] );
 
 		assertThat( $result, is( equalTo( '<p>before string after</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithMustacheFilter_ReplacesVariableWithGivenCallbackReturnValue() {
+	public function testTemplateWithMustacheFilter_ReplacesVariableWithGivenCallbackReturnValue() {
 		$result = $this->createAndRender(
 			"<p>{{'ABC'|message}}</p>",
 			[],
@@ -175,37 +127,25 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p>some ABC message</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithTruthfulConditionInIf_IsNotRemoved() {
+	public function testTemplateWithTruthfulConditionInIf_IsNotRemoved() {
 		$result = $this->createAndRender( '<p><a v-if="variable"></a></p>', [ 'variable' => true ] );
 
 		assertThat( $result, is( equalTo( '<p><a></a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithUntruthfulConditionInIf_IsRemoved() {
+	public function testTemplateWithUntruthfulConditionInIf_IsRemoved() {
 		$result = $this->createAndRender( '<p><a v-if="variable"></a></p>', [ 'variable' => false ] );
 
 		assertThat( $result, is( equalTo( '<p></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithNegatedFalseInIf_IsNotRemoved() {
+	public function testTemplateWithNegatedFalseInIf_IsNotRemoved() {
 		$result = $this->createAndRender( '<p><a v-if="!variable"></a></p>', [ 'variable' => false ] );
 
 		assertThat( $result, is( equalTo( '<p><a></a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithIfElseBlockAndTruthfulCondition_ElseIsRemoved() {
+	public function testTemplateWithIfElseBlockAndTruthfulCondition_ElseIsRemoved() {
 		$result = $this->createAndRender(
 			'<p><a v-if="variable">if</a><a v-else>else</a></p>',
 			[ 'variable' => true ]
@@ -214,10 +154,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p><a>if</a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithIfElseBlockAndNontruthfulCondition_ElseIsDisplayed() {
+	public function testTemplateWithIfElseBlockAndNontruthfulCondition_ElseIsDisplayed() {
 		$result = $this->createAndRender(
 			'<p><a v-if="variable">if</a><a v-else>else</a></p>',
 			[ 'variable' => false ]
@@ -226,19 +163,13 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p><a>else</a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithForLoopAndEmptyArrayToIterate_NotRendered() {
+	public function testTemplateWithForLoopAndEmptyArrayToIterate_NotRendered() {
 		$result = $this->createAndRender( '<p><a v-for="item in list"></a></p>', [ 'list' => [] ] );
 
 		assertThat( $result, is( equalTo( '<p></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithForLoopAndSingleElementInArrayToIterate_RenderedOnce() {
+	public function testTemplateWithForLoopAndSingleElementInArrayToIterate_RenderedOnce() {
 		$result = $this->createAndRender(
 			'<p><a v-for="item in list"></a></p>',
 			[ 'list' => [ 1 ] ]
@@ -247,10 +178,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p><a></a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithForLoopAndMultipleElementsInArrayToIterate_RenderedMultipleTimes() {
+	public function testTemplateWithForLoopAndMultipleElementsInArrayToIterate_RenderedMultipleTimes() {
 		$result = $this->createAndRender(
 			'<p><a v-for="item in list"></a></p>',
 			[ 'list' => [ 1, 2 ] ]
@@ -259,10 +187,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p><a></a><a></a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithForLoopMustache_RendersCorrectValues() {
+	public function testTemplateWithForLoopMustache_RendersCorrectValues() {
 		$result = $this->createAndRender(
 			'<p><a v-for="item in list">{{item}}</a></p>',
 			[ 'list' => [ 1, 2 ] ]
@@ -271,19 +196,13 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p><a>1</a><a>2</a></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithAttributeBinding_ConditionIsFalse_AttributeIsNotRendered() {
+	public function testTemplateWithAttributeBinding_ConditionIsFalse_AttributeIsNotRendered() {
 		$result = $this->createAndRender( '<p :attr1="condition"></p>', [ 'condition' => false ] );
 
 		assertThat( $result, is( equalTo( '<p></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithAttributeBinding_ConditionIsTrue_AttributeIsRendered() {
+	public function testTemplateWithAttributeBinding_ConditionIsTrue_AttributeIsRendered() {
 		$result = $this->createAndRender(
 			'<p :disabled="condition"></p>',
 			[ 'condition' => true ]
@@ -292,10 +211,8 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p disabled></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithAttributeBinding_ConditionIsString_AttributeIsRenderedWithThatString() {
+	// phpcs:ignore Generic.Files.LineLength.TooLong
+	public function testTemplateWithAttributeBinding_ConditionIsString_AttributeIsRenderedWithThatString() {
 		//TODO Rename variable name
 		$result = $this->createAndRender(
 			'<p :attr1="condition"></p>',
@@ -305,10 +222,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p attr1="some string"></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithPropertyAccessInMustache_CorrectValueIsRendered() {
+	public function testTemplateWithPropertyAccessInMustache_CorrectValueIsRendered() {
 		$result = $this->createAndRender(
 			'<p>{{var.property}}</p>',
 			[ 'var' => [ 'property' => 'value' ] ]
@@ -317,10 +231,7 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p>value</p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithFilterAccessInAttributeBinding_CorrectValueIsRendered() {
+	public function testTemplateWithFilterAccessInAttributeBinding_CorrectValueIsRendered() {
 		$result = $this->createAndRender(
 			'<p :attr1="var.property|strtoupper"></p>',
 			[ 'var' => [ 'property' => 'value' ] ],
@@ -330,10 +241,8 @@ class TemplatingTest extends TestCase {
 		assertThat( $result, is( equalTo( '<p attr1="VALUE"></p>' ) ) );
 	}
 
-	/**
-	 * @test
-	 */
-	public function templateWithFilterAccessInAttributeBindingInsideTheLoop_CorrectValueIsRendered() {
+	// phpcs:ignore Generic.Files.LineLength.TooLong
+	public function testTemplateWithFilterAccessInAttributeBindingInsideTheLoop_CorrectValueIsRendered() {
 		$result = $this->createAndRender(
 			'<p><a v-for="item in items" :attr1="item.property|strtoupper"></a></p>',
 			[ 'items' => [


### PR DESCRIPTION
The previous version throws an error on PHP 7.3:

> "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

This requires some changes to the code. The largest volume in the diffstat is taken up by the change from `/** @test */` to `test…` in the function name; I converted most of these with the following Emacs query-replace-regexp substitution:

    /\*\*^J^I \* @test^J^I \*/^J^Ipublic function \(.\) → public function test\,(upcase \1)

(`^J` is a line break and `^I` a tab; you can input these by typing <kbd>C-q</kbd> (<kbd>Ctrl+Q</kbd>) and then <kbd>Ret</kbd>/<kbd>Tab</kbd>.)