### PR TITLE
Stop testing on old PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
-  - hhvm
+  - 7.3
+  - 7.4
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	],
 	"license": "LGPL-2.1-only",
 	"require": {
-		"php": ">=5.5.9"
+		"php": ">=7.2"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
PHP 5.5 and HHVM now fail in Travis CI, and given that MediaWiki now requires PHP 7.2 or later, I don’t think it’s necessary to try and0support older PHP versions than that.