### PR TITLE
Update wikibase-codesniffer to v1.2.0

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -6,7 +6,7 @@
 
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="101" />
+			<property name="lineLimit" value="120" />
 		</properties>
 	</rule>
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5.3",
-		"wikibase/wikibase-codesniffer": "^1.1.0"
+		"wikibase/wikibase-codesniffer": "^1.2.0"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/src/Component.php
+++ b/src/Component.php
@@ -72,7 +72,9 @@ class Component {
 		$document = new DOMDocument( '1.0', 'UTF-8' );
 
 		// Ensure $html is treated as UTF-8, see https://stackoverflow.com/a/8218649
-		if ( !$document->loadHTML( '<?xml encoding="utf-8" ?>' . $html ) ) {
+		// LIBXML_NOBLANKS Constant excludes "ghost nodes" to avoid violating
+		// vue's single root node constraint
+		if ( !$document->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOBLANKS ) ) {
 			//TODO Test failure
 		}
 


### PR DESCRIPTION
In addition, changed line length restriction to 120 (as this is the PSR-12 recommendation and there were plenty of cs warnings about violations to the 101 line length rule).

Bug: [T264836](https://phabricator.wikimedia.org/T264836)