### PR TITLE
Parse method calls more leniently

### DIFF
--- a/src/JsParsing/BasicJsExpressionParser.php
+++ b/src/JsParsing/BasicJsExpressionParser.php
@@ -23,7 +23,7 @@ class BasicJsExpressionParser implements JsExpressionParser {
 			return new NegationOperator( $this->parse( substr( $expression, 1 ) ) );
 		} elseif ( strncmp( $expression, "'", 1 ) === 0 ) {
 			return new StringLiteral( substr( $expression, 1, -1 ) );
-		} elseif ( preg_match( '/^(\w+?)\(\s*([\w.\-\']+?)\s*\)$/', $expression, $matches ) ) {
+		} elseif ( preg_match( '/^(\w+)\((.*)\)$/', $expression, $matches ) ) {
 			$methodName = $matches[1];
 			if ( !array_key_exists( $methodName, $this->methods ) ) {
 				throw new RuntimeException( "Method '{$methodName}' is undefined" );

--- a/tests/php/JsParsing/BasicJsExpressionParserTest.php
+++ b/tests/php/JsParsing/BasicJsExpressionParserTest.php
@@ -37,7 +37,7 @@ class BasicJsExpressionParserTest extends TestCase {
 		$this->assertFalse( $negation->evaluate( [ 'variable' => true ] ) );
 	}
 
-	public function testCanParseMethodCall_builtin() {
+	public function testCanParseMethodCall_builtin_variable() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser( [
 			'strtoupper' => 'strtoupper',
 		] );
@@ -48,28 +48,31 @@ class BasicJsExpressionParserTest extends TestCase {
 		$this->assertSame( 'ABC', $result );
 	}
 
-	public function testCanParseMethodCall_closure() {
+	public function testCanParseMethodCall_closure_string() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser( [
 			'strtoupper' => static function ( string $arg ) {
 				return strtoupper( $arg );
 			},
 		] );
 
-		$parsedExpression = $jsExpressionEvaluator->parse( 'strtoupper(var)' );
-		$result = $parsedExpression->evaluate( [ 'var' => 'abc' ] );
+		$parsedExpression = $jsExpressionEvaluator->parse( "strtoupper('abc')" );
+		$result = $parsedExpression->evaluate( [] );
 
 		$this->assertSame( 'ABC', $result );
 	}
 
-	public function testCanParseMethodCall_whitespace() {
+	public function testCanParseMethodCall_whitespace_nested() {
 		$jsExpressionEvaluator = new BasicJsExpressionParser( [
 			'strtoupper' => 'strtoupper',
+			'strrev' => 'strrev',
 		] );
 
-		$parsedExpression = $jsExpressionEvaluator->parse( ' strtoupper( var ) ' );
+		$parsedExpression = $jsExpressionEvaluator->parse(
+			' strrev( strtoupper( var ) ) '
+		);
 		$result = $parsedExpression->evaluate( [ 'var' => 'abc' ] );
 
-		$this->assertSame( 'ABC', $result );
+		$this->assertSame( 'CBA', $result );
 	}
 
 	public function testIgnoresTrailingAndLeadingSpaces() {


### PR DESCRIPTION
Allow the expression in the single argument to be anything at all, as long as there’s a matching closing parenthesis at the end. Because we don’t support binary operators or multiple arguments, we don’t need to worry about counting balanced parentheses or anything like that: if the close-paren at the very end of the string doesn’t belong to the open-paren at the beginning of the method call, then there must be a syntax error (or unsupported syntax) somewhere.