### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,27 +13,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Includes php7.4 - 8.3 and composer 2
-          # https://github.com/actions/runner-images/blob/releases/ubuntu20/20241023/images/ubuntu/Ubuntu2004-Readme.md#php-tools
           - php: '7.4'
-            os: ubuntu-20.04
           - php: '8.0'
-            os: ubuntu-20.04
           - php: '8.1'
-            os: ubuntu-20.04
           - php: '8.2'
-            os: ubuntu-20.04
           - php: '8.3'
-            os: ubuntu-20.04
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: Use PHP ${{ matrix.php }}
-      run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
 
     - name: Validate composer.json and composer.lock
       run: composer validate


### PR DESCRIPTION
The Ubuntu 20.04 LTS runner was [retired on 2025-04-15][1]; given how rarely we touch this library, I think jumping on the “ubuntu-latest” train has a higher chance of succeeding.

More recent Ubuntu images no longer contain several PHP versions ([a][2], [b][3]); the most common approach seems to be the `shivammathur/setup-php` action, so let’s use that.

[1]: https://github.com/actions/runner-images/issues/11101
[2]: https://github.com/actions/runner-images/blob/releases/ubuntu22/20250601/images/ubuntu/Ubuntu2204-Readme.md#php-tools
[3]: https://github.com/actions/runner-images/blob/releases/ubuntu24/20250601/images/ubuntu/Ubuntu2404-Readme.md#php-tools