### PR TITLE
Throw errors from HTML parsing

### DIFF
--- a/src/HtmlParser.php
+++ b/src/HtmlParser.php
@@ -28,7 +28,7 @@ class HtmlParser {
 		// LIBXML_NOBLANKS Constant excludes "ghost nodes" to avoid violating
 		// vue's single root node constraint
 		if ( !$document->loadHTML( '<?xml encoding="utf-8" ?>' . $html, LIBXML_NOBLANKS ) ) {
-			//TODO Test failure
+			throw new Exception( 'Failed to parse HTML' );
 		}
 
 		/** @var LibXMLError[] $errors */
@@ -41,9 +41,15 @@ class HtmlParser {
 			libxml_disable_entity_loader( $entityLoaderDisabled );
 		}
 
+		$exception = null;
 		foreach ( $errors as $error ) {
-			//TODO html5 tags can fail parsing
-			//TODO Throw an exception
+			if ( strpos( $error->message, 'Tag template invalid' ) === 0 ) {
+				continue;
+			}
+			$exception = new Exception( $error->message, $error->code, $exception );
+		}
+		if ( $exception !== null ) {
+			throw $exception;
 		}
 
 		return $document;

--- a/tests/php/HtmlParserTest.php
+++ b/tests/php/HtmlParserTest.php
@@ -63,4 +63,11 @@ class HtmlParserTest extends TestCase {
 		$this->parseAndGetRootNode( '<p></p><p></p>' );
 	}
 
+	public function testMalformedHtml(): void {
+		$htmlParser = new HtmlParser();
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unexpected end tag' );
+		$htmlParser->parseHtml( '</p>' );
+	}
+
 }


### PR DESCRIPTION
Replace some TODOs with actual exception throwing. The exceptions aren’t great, but at least they’re better than just ignoring the errors.

The first case doesn’t have a test because, as far as I can tell, it’s basically impossible to trigger. There are apparently [very few situations where `loadHTML()` will return false][1] rather than trying to fix up the markup somehow, and we’re already guaranteeing that the HTML isn’t empty and that the options are valid.

The second case can raise a variety of errors; just test one of them. Turning the array of `LibXMLError` instances (which aren’t `Throwable`) into a “tree” / “stack” of `Exception` instances isn’t super nice, but better than doing nothing or only throwing an `Exception` for the first error.

[1]: https://stackoverflow.com/a/79055330/1420237