### PR TITLE
Bump PHP requirement to 8.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,11 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.4'
-          - php: '8.0'
           - php: '8.1'
           - php: '8.2'
           - php: '8.3'
+          - php: '8.4'
 
     runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"ext-dom": "*",
 		"ext-libxml": "*",
-		"php": ">=7.2"
+		"php": ">=8.1"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Component.php
+++ b/src/Component.php
@@ -76,7 +76,7 @@ class Component {
 		}
 		/** @var DOMAttr $attribute */
 		foreach ( $node->attributes as $attribute ) {
-			if ( strpos( $attribute->name, 'v-on:' ) === 0 ) {
+			if ( str_starts_with( $attribute->name, 'v-on:' ) ) {
 				$node->removeAttribute( $attribute->name );
 			}
 		}

--- a/src/HtmlParser.php
+++ b/src/HtmlParser.php
@@ -43,7 +43,7 @@ class HtmlParser {
 
 		$exception = null;
 		foreach ( $errors as $error ) {
-			if ( strpos( $error->message, 'Tag template invalid' ) === 0 ) {
+			if ( str_starts_with( $error->message, 'Tag template invalid' ) ) {
 				continue;
 			}
 			$exception = new Exception( $error->message, $error->code, $exception );


### PR DESCRIPTION
----

While this has been contentious in other libraries in the past, my position is that this should not be considered a semver breaking change, because:

- PHP < 8.1 is [no longer supported](https://www.php.net/supported-versions.php) by PHP.
- Composer takes the PHP requirements into account when selecting a library version. If someone is still on PHP 7.4, Composer won’t install a newer version of this library, so nothing will break for them.
- The last bump (ef70bb58f2) was also in a patch release.