### PR TITLE
Support `@` shorthand for `v-on:` directive

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -74,7 +74,10 @@ class Component {
 		$attributesToRemove = [];
 		/** @var DOMAttr $attribute */
 		foreach ( $node->attributes as $attribute ) {
-			if ( str_starts_with( $attribute->name, 'v-on:' ) ) {
+			if (
+				str_starts_with( $attribute->name, 'v-on:' ) ||
+				str_starts_with( $attribute->name, '@' )
+			) {
 				$attributesToRemove[] = $attribute;
 			}
 		}

--- a/src/HtmlParser.php
+++ b/src/HtmlParser.php
@@ -48,6 +48,10 @@ class HtmlParser {
 				// discard "Tag xyz invalid" messages from libxml2 < 2.14.0(?)
 				continue;
 			}
+			if ( $msg === "error parsing attribute name\n" ) {
+				// discard these messages (e.g. @event="") from libxml < 2.14.0(?)
+				continue;
+			}
 			$exception = new Exception( $msg, $error->code, $exception );
 		}
 		if ( $exception !== null ) {

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -63,6 +63,12 @@ EOF;
 		$this->assertSame( '<p><b><a></a></b></p>', $result );
 	}
 
+	public function testTemplateHasOnClickHandlerWithShorthand_RemoveHandlerFromOutput(): void {
+		$result = $this->createAndRender( '<p @click="x"></p>', [] );
+
+		$this->assertSame( '<p></p>', $result );
+	}
+
 	public function testTemplateHasMultipleEventHandlers_RemoveAll(): void {
 		$result = $this->createAndRender( '<p v-on:click="x" v-on:keypress="y"></p>', [] );
 

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -39,25 +39,25 @@ EOF;
 		$this->assertSame( '<div></div>', $result );
 	}
 
-	public function testTemplateHasOnClickHandler_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandler_RemoveHandlerFromOutput() {
 		$result = $this->createAndRender( '<div v-on:click="doStuff"></div>', [] );
 
 		$this->assertSame( '<div></div>', $result );
 	}
 
-	public function testTemplateHasOnClickHandlerAndPreventDefault_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandlerAndPreventDefault_RemoveHandlerFromOutput() {
 		$result = $this->createAndRender( '<div v-on:click.prevent="doStuff"></div>', [] );
 
 		$this->assertSame( '<div></div>', $result );
 	}
 
-	public function testTemplateHasOnClickHandlerInSomeChildNode_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandlerInSomeChildNode_RemoveHandlerFromOutput() {
 		$result = $this->createAndRender( '<p><a v-on:click="doStuff"></a></p>', [] );
 
 		$this->assertSame( '<p><a></a></p>', $result );
 	}
 
-	public function testTemplateHasOnClickHandlerInGrandChildNode_RemoveHandlerFormOutput() {
+	public function testTemplateHasOnClickHandlerInGrandChildNode_RemoveHandlerFromOutput() {
 		$result = $this->createAndRender( '<p><b><a v-on:click="doStuff"></a></b></p>', [] );
 
 		$this->assertSame( '<p><b><a></a></b></p>', $result );


### PR DESCRIPTION
This is used in some WikibaseLexeme templates (albeit never in the server-rendered path as far as I can tell), so we should support it. There are two related problems: old versions of libxml2 complain about @-prefixed attribute names, and our code only checked for v-on:. Both are fairly simple to resolve.

The libxml2 error doesn’t happen on my system, so I assume it was fixed in some recent-ish version; [libxml2 2.14.0][1], which boasts a tokenizer “conform[ing] fully to HTML5” and “several non-standard syntax warnings […] removed”, seems like the most likely candidate, but I haven’t tested the behavior with different versions. But in any event, libxml2 is clearly able to parse the markup and produce a DOM that we can work with (as evidenced by the fact that the WikibaseLexeme template have worked for years before we started raising the libxml2 errors as exceptions in ba3f8e0bef / #32), so we can just ignore the errors.

[1]: https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.0.news
