### PR TITLE
Add complex expression handling with Peast

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 	"require": {
 		"ext-dom": "*",
 		"ext-libxml": "*",
-		"php": ">=8.1"
+		"php": ">=8.1",
+		"mck89/peast": "^1.17"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/JsParsing/JsDictionary.php
+++ b/src/JsParsing/JsDictionary.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\VueJsTemplating\JsParsing;
+
+class JsDictionary implements ParsedExpression {
+
+	private array $parsedExpressionMap;
+
+	public function __construct( $data ) {
+		$this->parsedExpressionMap = $data;
+	}
+
+	/**
+	 * @param array $data the data to be passed into the expression evaluations
+	 *
+	 * @return array the dictionary with expressions replaced with their evaluated values
+	 */
+	public function evaluate( array $data ) {
+		$result = [];
+		foreach ( $this->parsedExpressionMap as $key => $value ) {
+			$result[ $key ] = $value->evaluate( $data );
+		}
+		return $result;
+	}
+
+}

--- a/src/JsParsing/PeastExpressionConverter.php
+++ b/src/JsParsing/PeastExpressionConverter.php
@@ -1,0 +1,98 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\VueJsTemplating\JsParsing;
+
+use Peast\Syntax\Node\CallExpression;
+use Peast\Syntax\Node\Expression;
+use Peast\Syntax\Node\Identifier;
+use Peast\Syntax\Node\MemberExpression;
+use Peast\Syntax\Node\ObjectExpression;
+use Peast\Syntax\Node\StringLiteral as PeastStringLiteral;
+use Peast\Syntax\Node\UnaryExpression;
+
+use RuntimeException;
+
+class PeastExpressionConverter {
+
+	/** @var array a map of method names to their implementations in PHP */
+	protected array $methods;
+
+	public function __construct( array $methods ) {
+		$this->methods = $methods;
+	}
+
+	protected function convertUnaryExpression( UnaryExpression $expression ) {
+		if ( $expression->getOperator() !== '!' ) {
+			throw new RuntimeException( 'Unable to parse unary operator "' . $expression->getOperator() . '"' );
+		}
+		return new NegationOperator( $this->convertExpression( $expression->getArgument() ) );
+	}
+
+	protected function convertCallExpression( CallExpression $expression ) {
+		$methodName = $expression->getCallee()->getName();
+		if ( !array_key_exists( $methodName, $this->methods ) ) {
+			throw new RuntimeException( "Method '{$methodName}' is undefined" );
+		}
+		$method = $this->methods[$methodName];
+
+		return new MethodCall(
+			$method,
+			array_map( fn ( $exp ) => $this->convertExpression( $exp ), $expression->getArguments() )
+		);
+	}
+
+	protected function convertMemberExpression( MemberExpression $expression ) {
+		$parts = [];
+		while ( $expression !== null ) {
+			if ( get_class( $expression ) === MemberExpression::class ) {
+				$property = $expression->getProperty()->getName();
+				array_unshift( $parts, $property );
+				$expression = $expression->getObject();
+			} elseif ( get_class( $expression ) === Identifier::class ) {
+				array_unshift( $parts, $expression->getName() );
+				$expression = null;
+			} else {
+				throw new RuntimeException(
+					'Unable to parse member expression with nodes of type ' . get_class( $expression )
+				);
+			}
+		}
+		return new VariableAccess( $parts );
+	}
+
+	protected function convertObjectExpression( ObjectExpression $expression ) {
+		$parsedExpressionMap = [];
+		foreach ( $expression->getProperties() as $property ) {
+			$parsedExpressionMap[ $this->convertKeyToLiteral( $property->getKey() ) ] =
+				$this->convertExpression( $property->getValue() );
+		}
+		return new JsDictionary( $parsedExpressionMap );
+	}
+
+	public function convertExpression( Expression $expression ) {
+		return match( get_class( $expression ) ) {
+			UnaryExpression::class => $this->convertUnaryExpression( $expression ),
+			MemberExpression::class => $this->convertMemberExpression( $expression ),
+			PeastStringLiteral::class => new StringLiteral( $expression->getValue() ),
+			Identifier::class => new VariableAccess( [ $expression->getName() ] ),
+			CallExpression::class => $this->convertCallExpression( $expression ),
+			ObjectExpression::class => $this->convertObjectExpression( $expression ),
+			default => throw new RuntimeException(
+				'Unable to parse complex expression of type ' . get_class( $expression )
+			)
+		};
+	}
+
+	protected function convertKeyToLiteral( $key ) {
+		return match( get_class( $key ) ) {
+			PeastStringLiteral::class => $key->getValue(),
+			Identifier::class => $key->getName(),
+			default => throw new RuntimeException(
+				'Unable to extract name from dictionary key of type ' . get_class( $key )
+			)
+		};
+	}
+
+}

--- a/tests/php/JsParsing/BasicJsExpressionParserTest.php
+++ b/tests/php/JsParsing/BasicJsExpressionParserTest.php
@@ -42,8 +42,8 @@ class BasicJsExpressionParserTest extends TestCase {
 			'strtoupper' => 'strtoupper',
 		] );
 
-		$parsedExpression = $jsExpressionEvaluator->parse( 'strtoupper(var)' );
-		$result = $parsedExpression->evaluate( [ 'var' => 'abc' ] );
+		$parsedExpression = $jsExpressionEvaluator->parse( 'strtoupper(somevar)' );
+		$result = $parsedExpression->evaluate( [ 'somevar' => 'abc' ] );
 
 		$this->assertSame( 'ABC', $result );
 	}
@@ -68,9 +68,9 @@ class BasicJsExpressionParserTest extends TestCase {
 		] );
 
 		$parsedExpression = $jsExpressionEvaluator->parse(
-			' strrev( strtoupper( var ) ) '
+			' strrev( strtoupper( somevar ) ) '
 		);
-		$result = $parsedExpression->evaluate( [ 'var' => 'abc' ] );
+		$result = $parsedExpression->evaluate( [ 'somevar' => 'abc' ] );
 
 		$this->assertSame( 'CBA', $result );
 	}
@@ -84,4 +84,36 @@ class BasicJsExpressionParserTest extends TestCase {
 		$this->assertEquals( 'some string', $result );
 	}
 
+	public function testCanParse_simple_dictionary(): void {
+		$jsExpressionEvaluator = new BasicJsExpressionParser( [] );
+
+		$parsedExpression = $jsExpressionEvaluator->parse( "{ key: testProperty }" );
+		$result = $parsedExpression->evaluate( [ 'testProperty' => 1 ] );
+
+		$this->assertSame( [ "key" => 1 ], $result );
+	}
+
+	public function testCanParse_nested_values(): void {
+		$jsExpressionEvaluator = new BasicJsExpressionParser( [] );
+
+		$parsedExpression = $jsExpressionEvaluator->parse( "{ key: testObject.testDelegate.testProperty }" );
+		$result = $parsedExpression->evaluate( [ 'testObject' => [ 'testDelegate' => [ 'testProperty' => 1 ] ] ] );
+
+		$this->assertSame( [ "key" => 1 ], $result );
+	}
+
+	public function testCanParse_dictionary_with_string_keys(): void {
+		$jsExpressionEvaluator = new BasicJsExpressionParser( [] );
+
+		$parsedExpression = $jsExpressionEvaluator->parse(
+			"{ 'wikibase-mex-icon-expand-x-small': !showReferences.P321, " .
+			"'wikibase-mex-icon-collapse-x-small': showReferences.P321 }"
+		);
+		$result = $parsedExpression->evaluate( [ 'showReferences' => [ 'P321' => false ] ] );
+
+		$this->assertSame( [
+			"wikibase-mex-icon-expand-x-small" => true,
+			"wikibase-mex-icon-collapse-x-small" => false
+		], $result );
+	}
 }

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -253,8 +253,8 @@ EOF;
 
 	public function testTemplateWithPropertyAccessInMustache_CorrectValueIsRendered() {
 		$result = $this->createAndRender(
-			'<p>{{var.property}}</p>',
-			[ 'var' => [ 'property' => 'value' ] ]
+			'<p>{{variable.property}}</p>',
+			[ 'variable' => [ 'property' => 'value' ] ]
 		);
 
 		$this->assertSame( '<p>value</p>', $result );
@@ -262,8 +262,8 @@ EOF;
 
 	public function testTemplateWithMethodAccessInAttributeBinding_CorrectValueIsRendered() {
 		$result = $this->createAndRender(
-			'<p :attr1="strtoupper(var.property)"></p>',
-			[ 'var' => [ 'property' => 'value' ] ],
+			'<p :attr1="strtoupper(variable.property)"></p>',
+			[ 'variable' => [ 'property' => 'value' ] ],
 			[ 'strtoupper' => 'strtoupper' ]
 		);
 


### PR DESCRIPTION
Until now the Javascript expression handling has been limited to simple expressions and has used regexps to process the strings of Javascript code. As we move to support more advanced Vue features, we need to be able to process more complex Javascript expressions and need to move away from regexps.

Peast is a library that is already used in Mediawiki that converts Javascript expressions into an abstract syntax tree representation. Using Peast we can more reliably parse Javascript and implement more complex expression handling.

Refactor the existing BasicJsExpressionParser to use Peast, and add handling of Object expressions (`{ test: 'value' }`).

Bug: T396855