### PR TITLE
Handle array-type value substitution in Vue templates

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -87,6 +87,13 @@ class Component {
 		}
 	}
 
+	private function convertDataValueToString( $value ) {
+		if ( is_string( $value ) ) {
+			return $value;
+		}
+		return json_encode( $value );
+	}
+
 	/**
 	 * @param DOMNode $node
 	 * @param array $data
@@ -100,8 +107,7 @@ class Component {
 
 			foreach ( $matches['expression'] as $index => $expression ) {
 				$value = $this->app->evaluateExpression( $expression, $data );
-
-				$text = str_replace( $matches[0][$index], $value, $text );
+				$text = str_replace( $matches[0][$index], $this->convertDataValueToString( $value ), $text );
 			}
 
 			if ( $text !== $node->textContent ) {

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -346,6 +346,22 @@ EOF;
 		);
 	}
 
+	public function testMoustacheVariableWithArrayListTypeSubstitution() {
+		$result = $this->createAndRender(
+			'<p>{{ my.data.variable }}</p>',
+			[ 'my' => [ 'data' => [ 'variable' => [ 1, 2, 3 ] ] ] ]
+		);
+		$this->assertSame( '<p>[1,2,3]</p>', $result );
+	}
+
+	public function testMoustacheVariableWithArrayObjectTypeSubstitution() {
+		$result = $this->createAndRender(
+			'<p>{{ my.data.variable }}</p>',
+			[ 'my' => [ 'data' => [ 'variable' => [ "a" => "b", "c" => "d" ] ] ] ]
+		);
+		$this->assertSame( '<p>{"a":"b","c":"d"}</p>', $result );
+	}
+
 	/**
 	 * @param string $template HTML
 	 * @param array $data


### PR DESCRIPTION
Mustache variables may resolve to non-string elements in the PHP variables supplied to the template. This currently causes an error as `str_replace` will only replace a string with another string.

Add some basic support for more complex data, converting complex data types into their JSON representation before substituting them into the template.

Bug: T398192