### PR TITLE
Workaround for libxml double-free in PHP 8.1.21

### DIFF
--- a/tests/php/AppTest.php
+++ b/tests/php/AppTest.php
@@ -61,6 +61,16 @@ class AppTest extends TestCase {
 		$this->assertSame( '<div><p>obj = { a: A, b: B }</p></div>', $result );
 	}
 
+	public function testComponentSubstitutionPreservesOrder(): void {
+		$app = new App( [] );
+		$app->registerComponentTemplate( 'root', '<div><x-a></x-a><div><p>Following Text</p></div>' );
+		$app->registerComponentTemplate( 'x-a', '<p>obj = { a: 1, b: 2 }</p>' );
+
+		$result = $app->renderComponent( 'root', [] );
+
+		$this->assertSame( '<div><p>obj = { a: 1, b: 2 }</p><div><p>Following Text</p></div></div>', $result );
+	}
+
 	public function testComponentPropKebabCase(): void {
 		$app = new App( [] );
 		$app->registerComponentTemplate(


### PR DESCRIPTION
There is a quirky behaviour of the libxml integration in PHP 8.1.21 that results in "DOMException: Not Found Error" or in some cases a SEGFAULT when nodes are appended to the DOM adjacent to nodes that are being / have been removed from the DOM.

While we wait for our infrastructure (and especially mwcli (T388411)) to move away from the version that has the bug, add a workaround so that we can make progress with MEX development.

Bug: T398821