### PR TITLE
Don’t clone node in `handleRawHtml()`

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -319,11 +319,7 @@ class Component {
 			$variableName = $node->getAttribute( 'v-html' );
 			$node->removeAttribute( 'v-html' );
 
-			$newNode = $node->cloneNode( true );
-
-			$this->appendHTML( $newNode, $data[$variableName] );
-
-			$node->parentNode->replaceChild( $newNode, $node );
+			$this->appendHTML( $node, $data[$variableName] );
 		}
 	}
 

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -102,6 +102,15 @@ EOF;
 		$this->assertSame( '<div><div><p>some value</p></div></div>', $result );
 	}
 
+	public function testTemplateWithVhtmlVariableAndAttributeBinding_ReplacesBoth(): void {
+		$result = $this->createAndRender(
+			'<div><div :data-a="a" v-html="html"></div></div>',
+			[ 'a' => 'A', 'html' => '<p>HTML</p>' ]
+		);
+
+		$this->assertSame( '<div><div data-a="A"><p>HTML</p></div></div>', $result );
+	}
+
 	public function testTemplateWithVhtmlAndDiacritcsInValue_ReplacesVariableWithEncodedValue() {
 		$result = $this->createAndRender(
 			'<div><div v-html="value"></div></div>',


### PR DESCRIPTION
I don’t know why the code cloned the node before modifying it – there’s no explanation of this in #2, and the rest of the code is happy to modify nodes directly. However, this causes attribute binding on nodes with `v-html` to have no effect – after `handleRawHtml()`, the original node is skipped for further processing (`isRemovedFromTheDom()` returns true), and even if it wasn’t, handling attributes on it wouldn’t have any effect on the node that’s actually in the DOM now. Given that removing the cloning doesn’t seem to break any tests, let’s just remove it and add a test for attribute binding in conjunction with `v-html`.

Bug: T396633
Bug: T396634