### PR TITLE
Fix: Don't process `v-html` injected content as Vue template expressions

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -51,6 +51,7 @@ class Component {
 
 		if ( !$this->isTextNode( $node ) ) {
 			$this->stripEventHandlers( $node );
+			$existingChildren = iterator_to_array( $node->childNodes );
 			$this->handleFor( $node, $data );
 			$this->handleRawHtml( $node, $data );
 
@@ -59,7 +60,7 @@ class Component {
 					$this->handleAttributeBinding( $node, $data );
 					$this->handleConditionalNodes( $node->childNodes, $data );
 
-					foreach ( iterator_to_array( $node->childNodes ) as $childNode ) {
+					foreach ( $existingChildren as $childNode ) {
 						$this->handleNode( $childNode, $data );
 					}
 				}

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -129,7 +129,22 @@ EOF;
 				'<div><div v-html="value"></div></div>',
 				[ 'value' => '<p>한국어</p>' ],
 				'<div><div><p>한국어</p></div></div>'
-			]
+			],
+			'mustache-like syntax in v-html text value is not evaluated as template expression' => [
+				'<div v-html="value"></div>',
+				[ 'value' => 'text {{P}} text' ],
+				'<div>text {{P}} text</div>',
+			],
+			'mustache-like syntax in v-html html content is not evaluated as template expression' => [
+				'<div v-html="value"></div>',
+				[ 'value' => '<span>{{P}}</span>' ],
+				'<div><span>{{P}}</span></div>',
+			],
+			'mustache-like syntax in html content and is not re-evaluated as template expression' => [
+				'<div>{{A}}</div>',
+				[ 'A' => '{{B}}', 'B' => 'unused' ],
+				'<div>{{B}}</div>',
+			],
 		];
 	}
 


### PR DESCRIPTION
**Problem**
When a snak value contained text like {{P}}, the server-side renderer crashed with:
  `RuntimeException: Undefined variable 'P'`

This happened because after `handleRawHtml` injected HTML via `appendHTML`, the child traversal in `handleNode` would recurse into the newly-injected nodes and call `replaceMustacheVariables` on them .. treating user content like `{{P}}` as a Vue template expression.

HTML-entity-encoding the curly braces (&#123;) was not a viable workaround because `HtmlParser` uses `DOMDocument::loadHTML` which decodes entities back to { before creating text nodes.

**Fix**
In `handleNode`, take a snapshot of the node's children before `handleRawHtml` runs, then use that snapshot in the `foreach` traversal instead of the node's current children.

This means only the original template children are walked and processed for Vue directives. Any HTML injected by `v-html` is appended to the DOM but never passed to `handleNode` .. matching real Vue.js behaviour, where `v-html` content is treated as raw HTML and is never compiled as template expressions.

Bug: [T418104](https://phabricator.wikimedia.org/T418104)