### PR TITLE
Fix: Don't evaluate v-if/v-else inside v-html injected content

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -6,7 +6,6 @@ use DOMAttr;
 use DOMCharacterData;
 use DOMElement;
 use DOMNode;
-use DOMNodeList;
 use DOMText;
 use RuntimeException;
 
@@ -58,7 +57,7 @@ class Component {
 			if ( !$this->isRemovedFromTheDom( $node ) ) {
 				if ( !$this->handleComponent( $node, $data ) ) {
 					$this->handleAttributeBinding( $node, $data );
-					$this->handleConditionalNodes( $node->childNodes, $data );
+					$this->handleConditionalNodes( $existingChildren, $data );
 
 					foreach ( $existingChildren as $childNode ) {
 						$this->handleNode( $childNode, $data );
@@ -266,10 +265,10 @@ class Component {
 	}
 
 	/**
-	 * @param DOMNodeList $nodes
+	 * @param array $nodes
 	 * @param array $data
 	 */
-	private function handleConditionalNodes( DOMNodeList $nodes, array $data ) {
+	private function handleConditionalNodes( array $nodes, array $data ) {
 		// Iteration of iterator breaks if we try to remove items while iterating, so defer node
 		// removing until finished iterating.
 		$nodesToRemove = [];

--- a/tests/php/TemplatingTest.php
+++ b/tests/php/TemplatingTest.php
@@ -145,6 +145,16 @@ EOF;
 				[ 'A' => '{{B}}', 'B' => 'unused' ],
 				'<div>{{B}}</div>',
 			],
+			'v-if in v-html content is not evaluated' => [
+				'<div v-html="html"></div>',
+				[ 'html' => '<span v-if="false">content</span>' ],
+				'<div><span v-if="false">content</span></div>',
+			],
+			'v-else in v-html content is not evaluated' => [
+				'<div v-html="html"></div>',
+				[ 'html' => '<span v-else="true">content</span>' ],
+				'<div><span v-else="true">content</span></div>',
+			],
 		];
 	}
 


### PR DESCRIPTION
**Problem:**
When passing a `v-if` and similar attributes are being evaluated in the `v-html`  which should not happen.

A good observation from Lucas in the [PR comment](https://github.com/wmde/php-vuejs-templating/pull/52#discussion_r2873523937)
> template `<div v-html="html"></div>` and `[ 'html' => '<span v-if="false">content</span> ]` should evaluate to `<div><span v-if="false">content</span></div>` and not `<div></div>`.

**Cause:**
`handleConditionalNodes()` was passed the live child node list after `handleRawHtml()` ran, causing v-if/v-else-if/v-else attributes in `v-html` injected markup to be evaluated . Fixed by `snapshotting` children before `handleRawHtml()` and passing that snapshot instead, consistent with how recursive `handleNode()` calls already avoid reprocessing injected content.

_Note: I didn't create a test coverage for the `v-else-if` because I believe it is redundant and unnecessary._

Bug: [T419942](https://phabricator.wikimedia.org/T419942)